### PR TITLE
Fix logicalType typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "avroschema-definer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avroschema-definer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Avro Schema constructor",
   "main": "dist/index.js",
   "scripts": {

--- a/src/base.ts
+++ b/src/base.ts
@@ -30,15 +30,16 @@ export default class BaseSchema<T = any, S = BaseAvroSchema> {
     return this.copyWith({ plain })
   }
 
-  logicalType <N = T> (logicalType: Required<BaseAvroSchema>['logicalType'], raw?: { precision: number, scale?: number }): BaseSchema<N, S>;
-  logicalType <N = T> (logicalType: string, raw?: object): BaseSchema<N, S>;
-
   /**
    * Set logical type for the schema
    *
    * @reference http://avro.apache.org/docs/1.9.2/spec.html#Logical+Types
    */
-  logicalType <N = T> (logicalType: string, raw?: object): BaseSchema<N, S> {
+  logicalType (logicalType: Required<BaseAvroSchema>['logicalType'], raw?: { precision: number, scale?: number }): this;
+  logicalType (logicalType: string, raw?: object): this;
+  logicalType <N> (logicalType: Required<BaseAvroSchema>['logicalType'], raw?: { precision: number, scale?: number }): BaseSchema<N, S>;
+  logicalType <N> (logicalType: string, raw?: object): BaseSchema<N, S>;
+  logicalType <N> (logicalType: string, raw?: object): BaseSchema<N, S> {
     return this.copyWith({ plain: { logicalType, ...raw } }) as any
   }
 


### PR DESCRIPTION
Fix weird behaviour when infered type setted to `any` when using `logicalType()` without providing generic argument